### PR TITLE
feat: Add StoreKeeperDashboardHome component to Dashboard page

### DIFF
--- a/client/src/components/storeKeeper/StoreKeeperDashboardHome.jsx
+++ b/client/src/components/storeKeeper/StoreKeeperDashboardHome.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function StoreKeeperDashboardHome() {
+  return (
+    <div>StoreKeeperDashboardHome</div>
+  )
+}
+
+export default StoreKeeperDashboardHome

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -17,6 +17,7 @@ import DashDamageProduct from "../components/DashDamageProduct";
 import DashSaleHistory from "../components/DashSaleHistory";
 
 import DashSalesReport from "../components/DashSalesReport";
+import StoreKeeperDashboardHome from "../components/storeKeeper/StoreKeeperDashboardHome";
 
 
 export default function Dashboard() {
@@ -61,11 +62,13 @@ export default function Dashboard() {
       {tab === "products" && currentUser.role === "Seller" && (
         <DashSellerProducts />
       )}
+      {}
       {/* dash */}
       {tab === "dash" && currentUser.role === "Admin" && <DashboardComp />}
       {tab === "dash" && currentUser.role === "Seller" && (
         <SellerDashboardHome />
       )}
+      {tab === "dash" && currentUser.role === "StoreKeeper" && (<StoreKeeperDashboardHome />)}
       {/* pos */}
       {tab === "pos" && <DashPOS />}
       {/* salesReport */}


### PR DESCRIPTION
This commit adds the StoreKeeperDashboardHome component to the Dashboard page. This component will be rendered when the tab is set to "dash" and the current user's role is "StoreKeeper". This addition allows StoreKeepers to have their own specific dashboard view.