### PR TITLE
feat: Add "Products" link to DashSidebar

### DIFF
--- a/client/src/components/DashSidebar.jsx
+++ b/client/src/components/DashSidebar.jsx
@@ -187,6 +187,36 @@ export default function DashSidebar() {
 
             {currentUser.role === "Director" && (
               <>
+                <Link to="/dashboard?tab=products">
+                  <Sidebar.Item
+                    className="mt-2 mb-2"
+                    icon={HiShoppingBag}
+                    active={tab === "products"}
+                  >
+                    Products
+                  </Sidebar.Item>
+                </Link>
+
+                <Link to="/dashboard?tab=shops">
+                  <Sidebar.Item
+                    className="mt-2 mb-2"
+                    icon={IoMdHome}
+                    active={tab === "shops"}
+                  >
+                    Shops
+                  </Sidebar.Item>
+                </Link>
+
+                <Link to="/dashboard?tab=stores">
+                  <Sidebar.Item
+                    className="mt-2 mb-2"
+                    icon={HiBuildingStorefront}
+                    active={tab === "stores"}
+                  >
+                    Stores
+                  </Sidebar.Item>
+                </Link>
+
                 <Link to="/dashboard?tab=saleHistory">
                   <Sidebar.Item className="mt-2 mb-2" icon={HiClipboardList}>
                     Sales History
@@ -196,6 +226,16 @@ export default function DashSidebar() {
                 <Link to="/dashboard?tab=salesReport">
                   <Sidebar.Item className="mt-2 mb-2" icon={HiTable}>
                     Sales Report
+                  </Sidebar.Item>
+                </Link>
+
+                <Link to="/dashboard?tab=returnItems">
+                  <Sidebar.Item
+                    className="mt-2 mb-2"
+                    icon={MdAssignmentReturn}
+                    active={tab === "returnItems"}
+                  >
+                    Return Items
                   </Sidebar.Item>
                 </Link>
               </>

--- a/client/src/components/director/DashDirectorProducts.jsx
+++ b/client/src/components/director/DashDirectorProducts.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-function DashDirectorProducts() {
-  return (
-    <div>DashDirectorProducts</div>
-  )
-}
-
-export default DashDirectorProducts

--- a/client/src/components/director/DirectorDashboardHome.jsx
+++ b/client/src/components/director/DirectorDashboardHome.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-function DirectorDashboardHome() {
-  return (
-    <div>DirectorDashboardHome</div>
-  )
-}
-
-export default DirectorDashboardHome

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -19,8 +19,8 @@ import SellerDashboardHome from "../components/seller/SellerDashboardHome";
 
 import DashSalesReport from "../components/DashSalesReport";
 // import AccountantDashboardHome from "../components/accountant/AccountantDashboardHome";
-import DashDirectorProducts from "../components/director/DashDirectorProducts";
-import DirectorDashboardHome from "../components/director/DirectorDashboardHome";
+// import DashDirectorProducts from "../components/director/DashDirectorProducts";
+// import DirectorDashboardHome from "../components/director/DirectorDashboardHome";
 import StockQADashboardHome from "../components/stockqa/StockQADashboardHome";
 import DashStoreKeeperProducts from "../components/storeKeeper/DashStoreKeeperProducts";
 import DashStoreKeeperSendStock from "../components/storeKeeper/DashStoreKeeperSendStock";
@@ -76,9 +76,9 @@ export default function Dashboard() {
         <DashStoreKeeperProducts />
       )}
 
-      {tab === "products" && currentUser.role === "Director" && (
+      {/* {tab === "products" && currentUser.role === "Director" && (
         <DashDirectorProducts />
-      )}
+      )} */}
 
       {tab === "products" && currentUser.role === "Accountant" && (
         <DashProducts />
@@ -87,6 +87,7 @@ export default function Dashboard() {
       {/* dash */}
       {tab === "dash" && currentUser.role === "Admin" && <DashboardComp />}
       {tab === "dash" && currentUser.role === "Accountant" && <DashboardComp />}
+      {tab === "dash" && currentUser.role === "Director" && <DashboardComp />}
       {tab === "dash" && currentUser.role === "Seller" && (
         <SellerDashboardHome />
       )}
@@ -94,9 +95,9 @@ export default function Dashboard() {
         <StoreKeeperDashboardHome />
       )}
 
-      {tab === "dash" && currentUser.role === "Director" && (
+      {/* {tab === "dash" && currentUser.role === "Director" && (
         <DirectorDashboardHome />
-      )}
+      )} */}
 
       {/* {tab === "dash" && currentUser.role === "Accountant" && (
         <AccountantDashboardHome />


### PR DESCRIPTION
This commit adds a new link to the DashSidebar component, allowing users to navigate to the "Products" page in the dashboard. The link is represented by a Sidebar.Item component with an icon and the label "Products". This enhancement improves the navigation experience for users by providing easy access to the "Products" section of the dashboard.